### PR TITLE
Fix trailing_newline issue in Builder::build

### DIFF
--- a/src/rope/rope_builder.rs
+++ b/src/rope/rope_builder.rs
@@ -107,11 +107,11 @@ impl RopeBuilder {
     #[inline]
     pub fn build(mut self) -> Rope {
         if self.buffer_len_left > 0 {
-            self.rope_has_trailing_newline =
-                self.buffer.has_trailing_newline();
-
             self.buffer.left_summary =
                 ChunkSummary::from(self.buffer_left_chunk());
+
+            self.rope_has_trailing_newline =
+                self.buffer.has_trailing_newline();
 
             self.tree_builder.append(self.buffer);
         }

--- a/src/tree/tree.rs
+++ b/src/tree/tree.rs
@@ -1548,7 +1548,6 @@ mod tests {
     use core::ops::{Add, AddAssign, Sub, SubAssign};
 
     use super::*;
-    use crate::tree::Summarize;
 
     #[derive(Copy, Clone, Default, Debug, Eq, PartialEq)]
     pub struct Count {

--- a/tests/rope_builder.rs
+++ b/tests/rope_builder.rs
@@ -4,6 +4,14 @@ use common::LARGE;
 use crop::{Rope, RopeBuilder};
 
 #[test]
+fn builder_line_len() {
+    let mut builder = RopeBuilder::new();
+    builder.append("\n");
+    let rope = builder.build();
+    assert_eq!(rope.line_len(), Rope::from("\n").line_len());
+}
+
+#[test]
 fn builder_empty() {
     let r = RopeBuilder::new().build();
 


### PR DESCRIPTION
Hey! I found a little issue where building a rope using the builder would result in different line lengths compared to constructing the Rope directly (using `Rope::from`). 

`Buffer::has_trailing_newline` transitively depends on `len_left` which depends on `left_summary` being up to date. However, `Builder::finish` was calling them in the reverse order so this wouldn't work in some cases. 

Since `has_trailing_newline` is now false instead of true, the line length is too great by 1. 