### PR TITLE
Fix `is_grapheme_boundary` panic on empty rope

### DIFF
--- a/src/rope/utils.rs
+++ b/src/rope/utils.rs
@@ -158,6 +158,10 @@ pub(super) fn is_grapheme_boundary(
 
     debug_assert!(byte_offset <= byte_len);
 
+    if byte_len == 0 {
+        return byte_offset == 0;
+    }
+
     let mut cursor = GraphemeCursor::new(0, byte_len, true);
     cursor.set_cursor(byte_offset);
 

--- a/src/rope/utils.rs
+++ b/src/rope/utils.rs
@@ -159,7 +159,7 @@ pub(super) fn is_grapheme_boundary(
     debug_assert!(byte_offset <= byte_len);
 
     if byte_len == 0 {
-        return byte_offset == 0;
+        return true;
     }
 
     let mut cursor = GraphemeCursor::new(0, byte_len, true);

--- a/tests/graphemes.rs
+++ b/tests/graphemes.rs
@@ -138,3 +138,9 @@ fn graphemes_is_boundary_out_of_bounds() {
     let r = Rope::from("🇷🇸🇮🇴");
     assert!(r.is_grapheme_boundary(17));
 }
+
+#[cfg(feature = "graphemes")]
+#[test]
+fn graphemes_is_boundary_empty_rope() {
+    assert!(Rope::new().is_grapheme_boundary(0));
+}


### PR DESCRIPTION
`unwrap()` at `src/rope/utils.rs:172`:

https://github.com/nomad/crop/blob/ae8ac1669e1024df42b18ec3e26c3f8d933cebc2/src/rope/utils.rs#L172

If the rope is empty, the `chunks` iterator won't yield any items. We can avoid hitting this case, and do less work, if we recognize that an empty rope has one valid grapheme boundary, at byte offset 0.