### PR TITLE
Remove duplicated constants in graphemes bench

### DIFF
--- a/benches/graphemes.rs
+++ b/benches/graphemes.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::{LARGE, MEDIUM, SMALL, TINY};
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main, Criterion};
 use crop::Rope;
 
 fn iter_graphemes(c: &mut Criterion) {

--- a/benches/graphemes.rs
+++ b/benches/graphemes.rs
@@ -1,13 +1,8 @@
 mod common;
 
 use common::{LARGE, MEDIUM, SMALL, TINY};
-use criterion::{criterion_group, criterion_main, Criterion};
-use crop::{iter::Graphemes, Rope};
-
-const TINY: &str = include_str!("../tests/common/tiny.txt");
-const SMALL: &str = include_str!("../tests/common/small.txt");
-const MEDIUM: &str = include_str!("../tests/common/medium.txt");
-const LARGE: &str = include_str!("../tests/common/large.txt");
+use criterion::{Criterion, criterion_group, criterion_main};
+use crop::Rope;
 
 fn iter_graphemes(c: &mut Criterion) {
     let mut group = c.benchmark_group("iter_graphemes");


### PR DESCRIPTION
The graphemes benchmark code wasn't compiling.

<details>

<summary>Error</summary>

```
$ cargo build --all-targets --features graphemes
   Compiling crop v0.4.2 (/Users/evanrelf/Code/others/crop)
error[E0255]: the name `LARGE` is defined multiple times
  --> benches/graphemes.rs:10:1
   |
3  | use common::{LARGE, MEDIUM, SMALL, TINY};
   |              ----- previous import of the value `LARGE` here
...
10 | const LARGE: &str = include_str!("../tests/common/large.txt");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `LARGE` redefined here
   |
   = note: `LARGE` must be defined only once in the value namespace of this module
help: you can use `as` to change the binding name of the import
   |
3  | use common::{LARGE as OtherLARGE, MEDIUM, SMALL, TINY};
   |                    +++++++++++++

error[E0255]: the name `MEDIUM` is defined multiple times
 --> benches/graphemes.rs:9:1
  |
3 | use common::{LARGE, MEDIUM, SMALL, TINY};
  |                     ------ previous import of the value `MEDIUM` here
...
9 | const MEDIUM: &str = include_str!("../tests/common/medium.txt");
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MEDIUM` redefined here
  |
  = note: `MEDIUM` must be defined only once in the value namespace of this module
help: you can use `as` to change the binding name of the import
  |
3 | use common::{LARGE, MEDIUM as OtherMEDIUM, SMALL, TINY};
  |                            ++++++++++++++

error[E0255]: the name `SMALL` is defined multiple times
 --> benches/graphemes.rs:8:1
  |
3 | use common::{LARGE, MEDIUM, SMALL, TINY};
  |                             ----- previous import of the value `SMALL` here
...
8 | const SMALL: &str = include_str!("../tests/common/small.txt");
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SMALL` redefined here
  |
  = note: `SMALL` must be defined only once in the value namespace of this module
help: you can use `as` to change the binding name of the import
  |
3 | use common::{LARGE, MEDIUM, SMALL as OtherSMALL, TINY};
  |                                   +++++++++++++

error[E0255]: the name `TINY` is defined multiple times
 --> benches/graphemes.rs:7:1
  |
3 | use common::{LARGE, MEDIUM, SMALL, TINY};
  |                                    ---- previous import of the value `TINY` here
...
7 | const TINY: &str = include_str!("../tests/common/tiny.txt");
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `TINY` redefined here
  |
  = note: `TINY` must be defined only once in the value namespace of this module
help: you can use `as` to change the binding name of the import
  |
3 | use common::{LARGE, MEDIUM, SMALL, TINY as OtherTINY};
  |                                         ++++++++++++

warning: unused imports: `LARGE`, `MEDIUM`, `SMALL`, and `TINY`
 --> benches/graphemes.rs:3:14
  |
3 | use common::{LARGE, MEDIUM, SMALL, TINY};
  |              ^^^^^  ^^^^^^  ^^^^^  ^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused import: `iter::Graphemes`
 --> benches/graphemes.rs:5:12
  |
5 | use crop::{iter::Graphemes, Rope};
  |            ^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0255`.
warning: `crop` (bench "graphemes") generated 2 warnings
error: could not compile `crop` (bench "graphemes") due to 4 previous errors; 2 warnings emitted
```

</details>