### PR TITLE
Implement `Serialize` and `Deserialize` on `Rope`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@nightly
-      - run: cargo test --features graphemes,utf16-metric --no-fail-fast
+      - run: cargo test --features graphemes,serde,utf16-metric --no-fail-fast
 
   test-small-chunks-arity-prod:
     name: test-small-chunks-arity-prod
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@nightly
-      - run: cargo test --features graphemes,utf16-metric,small_chunks --no-fail-fast
+      - run: cargo test --features graphemes,serde,utf16-metric,small_chunks --no-fail-fast
 
   test-small-chunks-arity-4:
     name: test-small-chunks-arity-4
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@nightly
-      - run: cargo test --features graphemes,utf16-metric,arity_4,small_chunks --no-fail-fast
+      - run: cargo test --features graphemes,serde,utf16-metric,arity_4,small_chunks --no-fail-fast
 
   bench:
     name: bench
@@ -51,7 +51,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy
-      - run: cargo clippy --features graphemes,utf16-metric -- -D warnings
+      - run: cargo clippy --features graphemes,serde,utf16-metric -- -D warnings
 
   docs:
     name: docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Additions
+
+- added a new `serde` feature that enables the `Serialize` and `Deserialize`
+  implementations for `Rope` ([#27](https://github.com/nomad/crop/pull/27));
+
 ## [0.4.2] - Jan 22 2024
 
 ### Bug fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ criterion = "0.5"
 rand = "0.9"
 ropey = "1.6"
 serde_json = "1"
+serde_test = "1.0.177"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,13 @@ exclude = [
 ]
 
 [package.metadata.docs.rs]
-features = ["graphemes", "simd", "utf16-metric"]
+features = ["graphemes", "serde", "simd", "utf16-metric"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["simd", "std"]
 graphemes = ["unicode-segmentation"]
+serde = ["dep:serde"]
 simd = ["str_indices/simd"]
 utf16-metric = []
 std = []
@@ -38,13 +39,14 @@ dp = ["deep_trees"]
 
 [dependencies]
 str_indices = { version = "0.4.0", default-features = false }
+serde = { version = "1", optional = true }
 unicode-segmentation = { version = "1.10.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.5"
 rand = "0.9"
 ropey = "1.6"
-serde_json = "1.0"
+serde_json = "1"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ harness = false
 [[bench]]
 name = "serde"
 harness = false
+required-features = ["serde"]
 
 [[bench]]
 name = "slicing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ unicode-segmentation = { version = "1.10.0", optional = true }
 criterion = "0.5"
 rand = "0.9"
 ropey = "1.6"
+serde_json = "1.0"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
@@ -67,6 +68,10 @@ harness = false
 
 [[bench]]
 name = "metric_conversion"
+harness = false
+
+[[bench]]
+name = "serde"
 harness = false
 
 [[bench]]

--- a/benches/serde.rs
+++ b/benches/serde.rs
@@ -68,13 +68,11 @@ impl DataFormat for Json {
     type Serialized = String;
 
     fn serialize_rope(&self, rope: &Rope) -> Self::Serialized {
-        // serde_json::to_string(rope).unwrap()
-        todo!();
+        serde_json::to_string(rope).unwrap()
     }
 
     fn deserialize_rope(&self, serialized: Self::Serialized) -> Rope {
-        // serde_json::from_str(&serialized).unwrap()
-        todo!();
+        serde_json::from_str(&serialized).unwrap()
     }
 }
 

--- a/benches/serde.rs
+++ b/benches/serde.rs
@@ -1,0 +1,86 @@
+mod common;
+
+use common::{LARGE, MEDIUM, SMALL, TINY};
+use criterion::measurement::WallTime;
+use criterion::{
+    BatchSize,
+    BenchmarkGroup,
+    BenchmarkId,
+    Criterion,
+    criterion_group,
+    criterion_main,
+};
+use crop::Rope;
+
+trait DataFormat {
+    const GROUP_NAME: &str;
+
+    type Serialized: Clone;
+
+    fn serialize_rope(&self, rope: &Rope) -> Self::Serialized;
+
+    fn deserialize_rope(&self, serialized: Self::Serialized) -> Rope;
+
+    fn bench(&self, c: &mut Criterion) {
+        let mut group = c.benchmark_group(Self::GROUP_NAME);
+        self.bench_serialization(&mut group);
+        self.bench_deserialization(&mut group);
+        group.finish();
+    }
+
+    fn bench_serialization(&self, group: &mut BenchmarkGroup<'_, WallTime>) {
+        for (rope, rope_name) in test_vectors() {
+            let bench_id = BenchmarkId::new("ser", rope_name);
+            group.bench_function(bench_id, |b| {
+                b.iter(|| self.serialize_rope(&rope));
+            });
+        }
+    }
+
+    fn bench_deserialization(&self, group: &mut BenchmarkGroup<'_, WallTime>) {
+        for (rope, rope_name) in test_vectors() {
+            let serialized = self.serialize_rope(&rope);
+            let bench_id = BenchmarkId::new("de", rope_name);
+            group.bench_function(bench_id, |b| {
+                let setup = || serialized.clone();
+                let routine = |serialized| self.deserialize_rope(serialized);
+                b.iter_batched(setup, routine, BatchSize::SmallInput);
+            });
+        }
+    }
+}
+
+fn test_vectors() -> impl Iterator<Item = (Rope, &'static str)> {
+    [
+        (Rope::from(TINY), "tiny"),
+        (Rope::from(SMALL), "small"),
+        (Rope::from(MEDIUM), "medium"),
+        (Rope::from(LARGE), "large"),
+    ]
+    .into_iter()
+}
+
+struct Json;
+
+impl DataFormat for Json {
+    const GROUP_NAME: &str = "serde_json";
+
+    type Serialized = String;
+
+    fn serialize_rope(&self, rope: &Rope) -> Self::Serialized {
+        // serde_json::to_string(rope).unwrap()
+        todo!();
+    }
+
+    fn deserialize_rope(&self, serialized: Self::Serialized) -> Rope {
+        // serde_json::from_str(&serialized).unwrap()
+        todo!();
+    }
+}
+
+fn json(c: &mut Criterion) {
+    Json.bench(c);
+}
+
+criterion_group!(benches, json);
+criterion_main!(benches);

--- a/src/rope/rope.rs
+++ b/src/rope/rope.rs
@@ -960,3 +960,25 @@ impl core::cmp::PartialEq<Rope> for alloc::borrow::Cow<'_, str> {
 }
 
 impl core::cmp::Eq for Rope {}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Rope {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Rope {
+    #[inline]
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        String::deserialize(deserializer).map(Self::from)
+    }
+}

--- a/src/rope/rope.rs
+++ b/src/rope/rope.rs
@@ -962,23 +962,64 @@ impl core::cmp::PartialEq<Rope> for alloc::borrow::Cow<'_, str> {
 impl core::cmp::Eq for Rope {}
 
 #[cfg(feature = "serde")]
-impl serde::Serialize for Rope {
-    #[inline]
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.to_string())
-    }
-}
+mod serde_impls {
+    use alloc::borrow::Cow;
 
-#[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for Rope {
-    #[inline]
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        String::deserialize(deserializer).map(Self::from)
+    use serde::ser::SerializeSeq;
+
+    use super::*;
+    use crate::RopeBuilder;
+
+    impl serde::Serialize for Rope {
+        #[inline]
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            let mut seq = serializer.serialize_seq(None)?;
+            for chunk in self.chunks() {
+                seq.serialize_element(chunk)?;
+            }
+            seq.end()
+        }
+    }
+
+    impl<'de> serde::Deserialize<'de> for Rope {
+        #[inline]
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            struct Visitor;
+
+            impl<'de> serde::de::Visitor<'de> for Visitor {
+                type Value = Rope;
+
+                #[inline]
+                fn expecting(
+                    &self,
+                    formatter: &mut core::fmt::Formatter,
+                ) -> core::fmt::Result {
+                    formatter.write_str("a sequence of chunks")
+                }
+
+                #[inline]
+                fn visit_seq<A>(
+                    self,
+                    mut seq: A,
+                ) -> Result<Self::Value, A::Error>
+                where
+                    A: serde::de::SeqAccess<'de>,
+                {
+                    let mut builder = RopeBuilder::new();
+                    while let Some(chunk) = seq.next_element::<Cow<str>>()? {
+                        builder.append(chunk);
+                    }
+                    Ok(builder.build())
+                }
+            }
+
+            deserializer.deserialize_seq(Visitor)
+        }
     }
 }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,80 @@
+#[cfg(feature = "serde")]
+mod tests {
+    use crop::Rope;
+
+    #[test]
+    fn ser_de_empty() {
+        let rope = Rope::new();
+
+        serde_test::assert_tokens(
+            &rope,
+            &[serde_test::Token::Seq { len: None }, serde_test::Token::SeqEnd],
+        );
+    }
+
+    #[test]
+    fn ser_de_single_chunk() {
+        let mut rope = Rope::new();
+        rope.insert(0, "lorem ");
+        rope.insert(6, "ipsum");
+
+        serde_test::assert_tokens(
+            &rope,
+            &[
+                serde_test::Token::Seq { len: None },
+                serde_test::Token::Str("lorem ipsum"),
+                serde_test::Token::SeqEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn ser_de_multiple_chunks() {
+        let mut rope = Rope::new();
+        rope.insert(0, "lorem dolor");
+        rope.insert(6, "ipsuma ");
+        rope.delete(11..12);
+
+        serde_test::assert_tokens(
+            &rope,
+            &[
+                serde_test::Token::Seq { len: None },
+                serde_test::Token::Str("lorem ipsum"),
+                serde_test::Token::Str(" dolor"),
+                serde_test::Token::SeqEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn ser_de_lf() {
+        let mut rope = Rope::new();
+        rope.insert(0, "lorem\n");
+        rope.insert(6, "ipsum");
+
+        serde_test::assert_tokens(
+            &rope,
+            &[
+                serde_test::Token::Seq { len: None },
+                serde_test::Token::Str("lorem\nipsum"),
+                serde_test::Token::SeqEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn ser_de_crlf() {
+        let mut rope = Rope::new();
+        rope.insert(0, "lorem\r\n");
+        rope.insert(7, "ipsum");
+
+        serde_test::assert_tokens(
+            &rope,
+            &[
+                serde_test::Token::Seq { len: None },
+                serde_test::Token::Str("lorem\r\nipsum"),
+                serde_test::Token::SeqEnd,
+            ],
+        );
+    }
+}

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -13,6 +13,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(feature = "small_chunks", ignore)]
     fn ser_de_single_chunk() {
         let mut rope = Rope::new();
         rope.insert(0, "lorem ");
@@ -29,6 +30,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(feature = "small_chunks", ignore)]
     fn ser_de_multiple_chunks() {
         let mut rope = Rope::new();
         rope.insert(0, "lorem dolor");
@@ -47,6 +49,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(feature = "small_chunks", ignore)]
     fn ser_de_lf() {
         let mut rope = Rope::new();
         rope.insert(0, "lorem\n");
@@ -63,6 +66,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(feature = "small_chunks", ignore)]
     fn ser_de_crlf() {
         let mut rope = Rope::new();
         rope.insert(0, "lorem\r\n");


### PR DESCRIPTION
Closes #26.

## (De)serialize to/from strings

```
serde_json/ser/tiny:   1.1402 µs
serde_json/ser/small:  1.8021 µs
serde_json/ser/medium: 160.98 µs
serde_json/ser/large:  1.1537 ms

serde_json/de/tiny:    1.5186 µs
serde_json/de/small:   2.1216 µs
serde_json/de/medium:  230.88 µs
serde_json/de/large:   1.7968 ms
```

## (De)serialize to/from chunks

```
serde_json/ser/tiny:   835.79 ns
serde_json/ser/small:  1.5530 µs
serde_json/ser/medium: 151.15 µs
serde_json/ser/large:  1.0774 ms

serde_json/de/tiny:    1.6713 µs
serde_json/de/small:   2.2025 µs
serde_json/de/medium:  227.74 µs
serde_json/de/large:   1.5861 ms
```

Overall, (de)serializing via chunks seems to be +5 to +35% faster when serializing, and -10 to +13% faster when deserializing compared to (de)serializing via strings.